### PR TITLE
After authentication, redirect a user to the hopauth index page

### DIFF
--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/login.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/login.html
@@ -1,6 +1,6 @@
 <html>
   <body>
     <h1>SCIMMA Auth</h1>
-    <a href="{% url 'oidc_authentication_init' %}">Login</a>
+    <a href="{% url 'oidc_authentication_init' %}?next={% url 'index' %}">Login</a>
   </body>
 </html>


### PR DESCRIPTION
Without this, users got redirected to the root, /, which doesn't really show anything.

After this change, redirection ought to work. Fixes #6 