### PR TITLE
Look up user identities by their vo_person_id, not email

### DIFF
--- a/scimma_admin/hopskotch_auth/auth.py
+++ b/scimma_admin/hopskotch_auth/auth.py
@@ -12,13 +12,13 @@ class HopskotchOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
     """Subclass Mozilla's OIDC Auth backend for custom hopskotch behavior. """
 
     def filter_users_by_claims(self, claims):
-        email = claims.get("email")
-        if isinstance(email, list):
-            claims["email"] = email[0]
-        return super(HopskotchOIDCAuthenticationBackend, self).filter_users_by_claims(claims)
+        username = claims.get("vo_person_id")
+        if not username:
+            return self.UserModel.objects.none()
+        return self.UserModel.objects.filter(username=username)
 
     def get_username(self, claims):
-        return claims['vo_display_name']
+        return claims.get("vo_person_id")
 
     def verify_claims(self, claims):
         logger.info(f"all claims: {claims}")

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/index.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/index.html
@@ -49,7 +49,7 @@
     {% if user.is_authenticated %}
     <h1>SCIMMA Auth</h1>
     <section class="logged-in-status">
-      <p>Current user: {{ user.email }}</p>
+      <p>Current user: {{ user.email }} ({{ user.username }})</p>
       <form action="{% url 'oidc_logout' %}" method="post">
         {% csrf_token %}
         <input type="submit" value="logout">


### PR DESCRIPTION
We need to identify users by their `vo_person_id` from COmanage, not by their email address. Email addresses might not be unique, but vo_person_id always is.