### PR TITLE
Make the LDAP group used to authorize Kafka access configurable

### DIFF
--- a/scimma_admin/hopskotch_auth/auth.py
+++ b/scimma_admin/hopskotch_auth/auth.py
@@ -3,7 +3,7 @@ from mozilla_django_oidc import auth
 from django.contrib import messages
 import logging
 import secrets
-import os
+from django.conf import settings
 
 
 logger = logging.getLogger(__name__)
@@ -14,12 +14,10 @@ class NotInKafkaUsers(PermissionDenied):
 
 class HopskotchOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
     """Subclass Mozilla's OIDC Auth backend for custom hopskotch behavior. """
+
     def __init__(self):
         auth.OIDCAuthenticationBackend.__init__(self)
-        if "KAFKA_USER_AUTH_GROUP" in os.environ:
-            self.kafka_user_auth_group=os.environ["KAFKA_USER_AUTH_GROUP"]
-        else:
-            self.kafka_user_auth_group="kafkaUsers"
+        self.kafka_user_auth_group = settings.KAFKA_USER_AUTH_GROUP
 
     def filter_users_by_claims(self, claims):
         username = claims.get("vo_person_id")

--- a/scimma_admin/scimma_admin/settings.py
+++ b/scimma_admin/scimma_admin/settings.py
@@ -215,6 +215,8 @@ LOGGING = {
 # TLS termination is handled by an AWS ALB in production
 SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
+KAFKA_USER_AUTH_GROUP = os.environ.get("KAFKA_USER_AUTH_GROUP", default="kafkaUsers")
+
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION
The original behavior is preserved as the default. 