### PR TITLE
Fix the new user login bug by correctly reporting new user objects we create

### DIFF
--- a/scimma_admin/hopskotch_auth/auth.py
+++ b/scimma_admin/hopskotch_auth/auth.py
@@ -52,7 +52,7 @@ class HopskotchOIDCAuthenticationBackend(auth.OIDCAuthenticationBackend):
         if isinstance(email, list):
             claims["email"] = email[0]
 
-        self.UserModel.objects.create(
+        return self.UserModel.objects.create(
             username=claims["vo_person_id"],
             email=claims["email"],
             is_staff=is_member_of(claims, 'CO:COU:SCiMMA DevOps:members:active'),


### PR DESCRIPTION
The issue we were seeing (where new users would inexplicably end up on the root page which just says 'OK') turns out to be due to the login process failing at the very end. The condition at https://github.com/mozilla/mozilla-django-oidc/blob/master/mozilla_django_oidc/views.py#L101 was not being met, and indeed, `self.user` was `None`. `authenticate` gets the user from `get_or_create_user`: https://github.com/mozilla/mozilla-django-oidc/blob/master/mozilla_django_oidc/auth.py#L290 , which will, in turn call `create_user` if the user is new: https://github.com/mozilla/mozilla-django-oidc/blob/master/mozilla_django_oidc/auth.py#L329 , which we had overridden in such a way that it did not return the new object. A subsequent log in attempt would succeed, because `filter_users_by_claims` would be able to find the user object persisted in the database. 