### PR TITLE
Prefix all topic names with the owning group name

### DIFF
--- a/scimma_admin/hopskotch_auth/models.py
+++ b/scimma_admin/hopskotch_auth/models.py
@@ -225,6 +225,20 @@ class Group(models.Model):
     )
 
 
+# This function interacts with validate_topic_name, because we want to form topic names as
+# ${group_name}.${topic}, so all group names must be compatible with this. This requires:
+# 1. using no characters which are invalid in Kafka topic names
+# 2. having a length short enough that there is room to fit the separator and a topic name within
+#    the length allowed by kafka
+# 3. group names should not include the separator character, '.', as this could lead to ambiguous
+#    topic names
+def validate_group_name(name: str) -> bool:
+    # due to requirements 1 and 3 the set of valid characters is the set allowed by kafka except '.'
+    # due to requiremment 2 the maximum allowed length is 2 less than the maximum allowed by kafka
+    valid = re.compile("^[a-zA-Z0-9_-]{1,247}$")
+    return re.match(valid, name)
+
+
 class GroupMembership(models.Model):
     user = models.ForeignKey(
         settings.AUTH_USER_MODEL,

--- a/scimma_admin/hopskotch_auth/models.py
+++ b/scimma_admin/hopskotch_auth/models.py
@@ -236,7 +236,7 @@ def validate_group_name(name: str) -> bool:
     # due to requirements 1 and 3 the set of valid characters is the set allowed by kafka except '.'
     # due to requiremment 2 the maximum allowed length is 2 less than the maximum allowed by kafka
     valid = re.compile("^[a-zA-Z0-9_-]{1,247}$")
-    return re.match(valid, name)
+    return re.match(valid, name) is not None
 
 
 class GroupMembership(models.Model):
@@ -287,7 +287,7 @@ class KafkaTopic(models.Model):
 def validate_topic_name(name: str) -> bool:
     # https://github.com/apache/kafka/blob/bc55f85237cb46e73c6774298cf308060a4a739c/clients/src/main/java/org/apache/kafka/common/internals/Topic.java#L30
     valid = re.compile("^[a-zA-Z0-9._-]{1,249}$")
-    return re.match(valid, name)
+    return re.match(valid, name) is not None
 
 
 class KafkaOperation(enum.Enum):

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/edit_group.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/edit_group.html
@@ -117,7 +117,8 @@
                 <input type="hidden" name="group_id" value="{{ group.id }}">
                 <div class="form-row">
                     <div class="col">
-                        <input class="form-control" placeholder="Topic Name" type="text" name="topic_name" class="vTextField" maxlength="249" required id="id_name">
+                        <span>{{ group.name }}.<input class="vTextField" placeholder="Topic Name" type="text" name="topic_name" class="vTextField" minlength="1" maxlength="249" pattern="[a-zA-Z0-9_-]{1,247}" required id="id_name"></span>
+                        <br>(Roman letters, digits, underscores, and dashes are allowed.)
                     </div>
                     <div class="col">
                         <button class="btn btn-outline-primary" type="submit" name="create">Create</button>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/edit_group.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/edit_group.html
@@ -117,7 +117,7 @@
                 <input type="hidden" name="group_id" value="{{ group.id }}">
                 <div class="form-row">
                     <div class="col">
-                        <span>{{ group.name }}.<input class="vTextField" placeholder="Topic Name" type="text" name="topic_name" class="vTextField" minlength="1" maxlength="249" pattern="[a-zA-Z0-9_-]{1,247}" required id="id_name"></span>
+                        <span>{{ group.name }}.<input class="vTextField" placeholder="topic_name" type="text" name="topic_name" class="vTextField" minlength="1" maxlength="247" pattern="[a-zA-Z0-9_-]{1,247}" required id="id_name"></span>
                         <br>(Roman letters, digits, underscores, and dashes are allowed.)
                     </div>
                     <div class="col">

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/group_management.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/group_management.html
@@ -41,9 +41,16 @@
             <h2>Create new group</h2>
             <form action="{% url 'create_group' %}" method="post">
                 {% csrf_token %}
-                <label class="required" for="id_name">Group Name</label>
-                <input type="text" name="name" class="vTextField" maxlength="256" required id="id_name">
-                <button class="btn btn-outline-primary" type="submit" name="create" id="create">Create</button>
+                <div class="form-row">
+                    <div class="col">
+                        <label class="required" for="id_name">Group Name</label>
+                        <input type="text" name="name" class="vTextField" minlength="1" maxlength="247" pattern="[a-zA-Z0-9_-]{1,247}" required id="id_name">
+                        <br>(Roman letters, digits, underscores, and dashes are allowed.)
+                    </div>
+                    <div class="col">
+                        <button class="btn btn-outline-primary" type="submit" name="create" id="create">Create</button>
+                    </div>
+                </div>
             </form>
         </section>
         <h3>


### PR DESCRIPTION
This change also limits the characters which may be used in group names, adds client-side validation of group, and topic names, and guidance to the user on allowed characters. 

No changes are made to existing topics, which will remain grandfathered in. 