### PR TITLE
Move the health check to its own path

### DIFF
--- a/scimma_admin/scimma_admin/urls.py
+++ b/scimma_admin/scimma_admin/urls.py
@@ -22,6 +22,7 @@ def OK(request):
 
 urlpatterns = [
     path('', OK),
+    path('health_check/', OK),
     path('admin/', admin.site.urls),
     path('hopauth/', include("hopskotch_auth.urls")),
     path('auth/', include('mozilla_django_oidc.urls')),


### PR DESCRIPTION
This will clear the way to put other things that make more sense to users at the root path. 