### PR TITLE
Run django tests in Github Actions

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,15 @@
+name: test
+
+on: [push]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - name: Build the stack
+        run: docker-compose up -d
+      - name: Run migrations
+        run: docker-compose exec django python manage.py migrate
+      - name: Run tests
+        run: docker-compose exec django python manage.py test

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Run migrations
-        run: docker-compose exec django python manage.py migrate --no-input
+        run: docker-compose exec -T django python manage.py migrate --no-input
 
       - name: Run tests
-        run: docker-compose exec django python manage.py test --no-input
+        run: docker-compose exec -T django python manage.py test --no-input

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -17,7 +17,7 @@ jobs:
         run: docker-compose up -d
 
       - name: Run migrations
-        run: docker-compose exec django python manage.py migrate
+        run: docker-compose exec django python manage.py migrate --no-input
 
       - name: Run tests
-        run: docker-compose exec django python manage.py test
+        run: docker-compose exec django python manage.py test --no-input

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -7,9 +7,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+
+      - name: Install secrets
+        env:
+          CILOGON_CLIENT_SECRET: ${{ secrets.CILOGON_CLIENT_SECRET }}
+        run: python scripts/setup_ci_secrets.py
+
       - name: Build the stack
         run: docker-compose up -d
+
       - name: Run migrations
         run: docker-compose exec django python manage.py migrate
+
       - name: Run tests
         run: docker-compose exec django python manage.py test

--- a/scripts/setup_ci_secrets.py
+++ b/scripts/setup_ci_secrets.py
@@ -8,7 +8,7 @@ FILENAME = "localdev.conf"
 def main():
     cp = configparser.ConfigParser()
     cp["secrets"] = {
-        "cilogon_client_secret": os.env["CILOGON_CLIENT_SECRET"],
+        "cilogon_client_secret": os.environ["CILOGON_CLIENT_SECRET"],
     }
     with open(FILENAME, "w") as f:
         cp.write(f)

--- a/scripts/setup_ci_secrets.py
+++ b/scripts/setup_ci_secrets.py
@@ -1,0 +1,19 @@
+import boto3
+import configparser
+import os
+
+
+FILENAME = "localdev.conf"
+
+
+def main():
+    cp = configparser.ConfigParser()
+    cp["secrets"] = {
+        "cilogon_client_secret": os.env["CILOGON_CLIENT_SECRET"],
+    }
+    with open(FILENAME, "w") as f:
+        cp.write(f)
+
+
+if __name__ == "__main__":
+    main()

--- a/scripts/setup_ci_secrets.py
+++ b/scripts/setup_ci_secrets.py
@@ -1,4 +1,3 @@
-import boto3
 import configparser
 import os
 


### PR DESCRIPTION
This teaches Github Actions to run `django manage.py test`, essentially.

Subtle parts:
 - We need a CILogon OIDC client secret. I added it to this repository, and it is fetched and installed in the same way that `make localdev-setup` works, but with a separate script. A little heavyweight, but I think it's ok.
 - `docker-compose exec` needs to be `docker-compose exec -T` to avoid allocating a pseudo-tty, which won't work inside GH actions.

Stuff works, as you can see in the checks here: https://github.com/scimma/scimma-admin/pull/38/checks?check_run_id=2248427783