### PR TITLE
Correctly detect prod environment to disable debug mode

### DIFF
--- a/scimma_admin/scimma_admin/settings.py
+++ b/scimma_admin/scimma_admin/settings.py
@@ -75,7 +75,7 @@ else:
     SECRET_KEY = "zzzlocal"
 
 # SECURITY WARNING: don't run with debug turned on in production!
-DEBUG = SCIMMA_ENVIRONMENT != "production"
+DEBUG = SCIMMA_ENVIRONMENT != "prod"
 
 # This looks scary, but it's OK because we always run behind a load balancer
 # which verifies the HTTP Host header for us. In production, that's an EKS Load


### PR DESCRIPTION
The SCIMMA_ENVIRONMENT variable is set to 'prod', not 'production'.

An explicit list of which environments _do_ get DEBUG=TRUE
might be preferable.