### PR TITLE
Tell the user why a log-in attmept failed.

### DIFF
--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/login.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/login.html
@@ -8,11 +8,14 @@
   <body>
     <h1>SCiMMA Auth</h1>
     <a href="{% url 'oidc_authentication_init' %}?next={% url 'index' %}" class="btn btn-primary">Login</a>
+    {% if signup_url %}
     <p>If you do not yet have an account, click
-        <a href="https://registry.scimma.org/registry/co_petitions/start/coef:127">here</a>
-        to create one. You should be able to sign up with your institutional single sign-on
+        <a href="{{ signup_url }}">here</a> to create one.
+    <p>You should be able to sign up with your institutional single sign-on
         credentials, or with another identity provider such as
-        <a href="http://orcid.org">http://orcid.org</a>. If using ORCID, please ensure that your
-        privacy settings allow your email address to be shared with 'trusted parties'.
+        <a href="http://orcid.org">http://orcid.org</a>.
+    <p>If using ORCID, please ensure that your privacy settings allow your email
+        address to be shared with 'trusted parties'.
+    {% endif %}
   </body>
 </html>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/login_failure.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/login_failure.html
@@ -2,5 +2,11 @@
 
 {% block page-body %}
     <h3>Login Failure</h3>
+    {% if reason %}
+    <p>Reason: {{ reason }}</p>
+    {% endif %}
+    {% if signup_url %}
+    <p>If you have not previously signed up for an account, you can do so <a href="{{ signup_url }}">here</a>.</p>
+    {% endif %}
     <a href="{% url 'oidc_authentication_init' %}?next={% url 'index' %}" class="btn btn-primary">Login</a>
 {% endblock %}

--- a/scimma_admin/hopskotch_auth/views.py
+++ b/scimma_admin/hopskotch_auth/views.py
@@ -52,7 +52,8 @@ def index(request):
 def login(request):
     if request.user.is_authenticated:
         return redirect(settings.LOGIN_REDIRECT_URL)
-    return render(request, 'hopskotch_auth/login.html',)
+    return render(request, 'hopskotch_auth/login.html',
+                  {"signup_url":settings.USER_SIGNUP_URL})
 
 
 def logout(request):
@@ -60,7 +61,12 @@ def logout(request):
 
 
 def login_failure(request):
-    return render(request, 'hopskotch_auth/login_failure.html')
+    if "login_failure_reason" in request.session:
+        reason = request.session["login_failure_reason"]
+    else:
+        reason = None
+    return render(request, 'hopskotch_auth/login_failure.html',
+                  {"reason":reason, "signup_url":settings.USER_SIGNUP_URL})
 
 
 @require_POST

--- a/scimma_admin/scimma_admin/settings.py
+++ b/scimma_admin/scimma_admin/settings.py
@@ -249,6 +249,9 @@ SECURE_PROXY_SSL_HEADER = ("HTTP_X_FORWARDED_PROTO", "https")
 
 KAFKA_USER_AUTH_GROUP = os.environ.get("KAFKA_USER_AUTH_GROUP", default="kafkaUsers")
 
+# This URL will be shown to users as the place they should go to create accounts
+USER_SIGNUP_URL = os.environ.get("USER_SIGNUP_URL", default=None)
+
 try:
     from local_settings import *
 except ImportError:


### PR DESCRIPTION
If relevant, suggest that the user create an account.
Add support for setting the account creation URL.

After mergin this patch, the Kubernetes deployments will need to be updated in terraform to set the new variable. 