### PR TITLE
Permissions UI refactor

### DIFF
--- a/scimma_admin/hopskotch_auth/callbacks.py
+++ b/scimma_admin/hopskotch_auth/callbacks.py
@@ -35,7 +35,7 @@ def add_all_credential_permission(request: AuthenticatedHttpRequest) -> JsonResp
 
 @login_required
 def add_credential_permissions(request: AuthenticatedHttpRequest) -> JsonResponse:
-    log_request(request, "adding a credential permission")
+    log_request(request, "add a credential permission")
     credname = request.POST['credname']
     topicname = request.POST['topicname']
     perms = request.POST.getlist('permission[]')
@@ -62,13 +62,14 @@ def add_credential_permissions(request: AuthenticatedHttpRequest) -> JsonRespons
 
 @login_required
 def remove_credential_permissions(request: AuthenticatedHttpRequest) -> JsonResponse:
+    log_request(request, "remove a credential permission")
     print(request.POST)
     credname = request.POST['credname']
     topicname = request.POST['topicname']
     perms = request.POST.getlist('permission[]')
 
     if isinstance(perms, str):
-        perms = ['perms']
+        perms = [perms]
     topic_result = engine.get_topic(topicname)
     if not topic_result:
         return json_with_error(request, "remove_credential_permission", topic_result.err())
@@ -81,6 +82,8 @@ def remove_credential_permissions(request: AuthenticatedHttpRequest) -> JsonResp
         except Exception:
             return json_with_error(request, "remove_credential_permission", Error('Bad permission name: {}'.format(perm.lower()), 400))
         rem_result = engine.remove_credential_permission(request.user, credname, topicname, perm_result)
+        if not rem_result:
+            return json_with_error(request, "remove_credential_permission", rem_result.err())
     return JsonResponse(data={}, status=200)
 
 # TODO: the name and implementation of this function are inconsistent: does it get (accessible)

--- a/scimma_admin/hopskotch_auth/static/hopskotch_auth/css/main.css
+++ b/scimma_admin/hopskotch_auth/static/hopskotch_auth/css/main.css
@@ -1,5 +1,4 @@
 body {
-  padding-top: 5rem;
 }
 
 .navbar-brand > img {

--- a/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_credential.js
+++ b/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_credential.js
@@ -54,6 +54,7 @@ $(document).ready(function() {
     function addPermCallback(){
         var credname = $('#idNameField').val();
         var spanElem = $(this).closest('span');
+        var brElem = $(spanElem).next();
         var trElem = $(this).closest('tr');
         var topic_name = $(trElem).find('td.topic_name').text();
         var topic_desc = $(trElem).find('td.topic_desc').text();
@@ -94,6 +95,7 @@ $(document).ready(function() {
                 $(otherTr).find('td.operations').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-danger remPerm objectModifier\">Remove</button></span> <br>");
                 //remove from this table, removing the whole row if empty
                 spanElem.remove();
+                brElem.remove();
                 var items = $(trElem).find('td.operations span').length;
                 if(items==0)
                     avail_table.row(trElem).remove().draw(false);
@@ -104,6 +106,7 @@ $(document).ready(function() {
     function remPermCallback(){
         var credname = $('#idNameField').val();
         var spanElem = $(this).closest('span');
+        var brElem = $(spanElem).next();
         var trElem = $(this).closest('tr');
         var topic_name = $(trElem).find('td.topic_name').text();
         var topic_desc = $(trElem).find('td.topic_desc').text();
@@ -144,6 +147,7 @@ $(document).ready(function() {
                 $(otherTr).find('td.operations').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-primary addPerm objectModifier\">Add</button></span> <br>");
                 //remove from this table, removing the whole row if empty
                 spanElem.remove();
+                brElem.remove();
                 var items = $(trElem).find('td.operations span').length;
                 if(items==0)
                     added_table.row(trElem).remove().draw(false);

--- a/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_credential.js
+++ b/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_credential.js
@@ -90,7 +90,6 @@ $(document).ready(function() {
                 let cur_row=added_table.row((idx, data) => data[0] == topic_name)
                 if(cur_row.length==0)
                     cur_row=added_table.row.add([topic_name, topic_desc, topic_access, ""]).draw(false);
-                console.log(cur_row);
                 var otherTr=cur_row.node();
                 $(otherTr).find('td.operations').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-danger remPerm objectModifier\">Remove</button></span> <br>");
                 //remove from this table, removing the whole row if empty
@@ -141,7 +140,6 @@ $(document).ready(function() {
                 let cur_row=avail_table.row((idx, data) => data[0] == topic_name)
                 if(cur_row.length==0)
                     cur_row=avail_table.row.add([topic_name, topic_desc, topic_access, ""]).draw(false);
-                console.log(cur_row);
                 var otherTr=cur_row.node();
                 $(otherTr).find('td.operations').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-primary addPerm objectModifier\">Add</button></span> <br>");
                 //remove from this table, removing the whole row if empty

--- a/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_credential.js
+++ b/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_credential.js
@@ -22,8 +22,6 @@ function getCookie(c_name)
  }
 
 $(document).ready(function() {
-    all_perms = ['Read', 'Write', 'Create', 'Delete', 'Alter', 'Describe', 'ClusterAction', 'DescribeConfigs', 'AlterConfigs', 'IdempotentWrite'];
-  line_count = $('#added_permissions > tbody > tr').length;
 
   function initializeModal() {
     modalElem = $('#topicPermEditModal');
@@ -38,7 +36,7 @@ $(document).ready(function() {
           {'className': 'topic_name'},
           {'className': 'topic_desc'},
           {'className': 'topic_access', 'searchable': false},
-          {'searchable': false, 'orderable': false}
+          {'className': 'operations', 'searchable': false, 'orderable': false}
       ]
   });
 
@@ -48,174 +46,113 @@ $(document).ready(function() {
         {'className': 'topic_name'},
         {'className': 'topic_desc'},
         {'className': 'topic_access'},
-        {'className': 'perm_boxes', 'searchable': false, 'orderable': false},
-        {'className': 'remove_button', 'searchable': false, 'orderable': false},
+        {'className': 'operations', 'searchable': false, 'orderable': false},
     ]
   })
-
-  table_1_format = '\
-    <tr>\
-    <td class="topic_name">{}</td>\
-    <td class="topic_desc">{}</td>\
-    <td class="topic_access">{}</td>\
-    <td class="perm_boxes">Read <input type="checkbox" class="form-check-input readCheck" checked> Write <input type="checkbox" class="form-check-input writeCheck"></td>\
-    <td scope="col" class="remove_button"><button type="button" class="btn btn-danger removeFrom objectModifier">Remove</button></td>\
-    </tr>\
-  '
-
-  perm_box_format = 'Read <input type="checkbox" class="form-check-input readCheck" checked> Write <input type="checkbox" class="form-check-input writeCheck">'
-  remove_button_format = '<button type="button" class="btn btn-danger removeFrom objectModifier">Remove</button>'
-
-  table_2_format = '\
-    <tr>\
-    <td class="topic_name">{}</td>\
-    <td class="topic_desc">{}</td>\
-    <td class="topic_access">{}</td>\
-    <td><button type="button" class="btn btn-primary addToCur">Add</button></td>\
-    </tr>\
-  '
-
-  add_button_format = '<button type="button" class="btn btn-primary addToCur">Add</button>'
-
-  function addToCurCallback() {
-      var trElem = $(this).closest('tr');
-      var topic_name = $(trElem).find('td.topic_name').text();
-      var topic_desc = $(trElem).find('td.topic_desc').text();
-      var topic_access = $(trElem).find('td.topic_access').text();
-      var credname = $('#idNameField').val();
-      var trElem = $(this).closest('tr');
-      var topic_name = $(trElem).find('td.topic_name').text();
-      acp_link = $('#acp_url').data().link;
-      $.ajax({
-        url: acp_link,
-        method: "POST",
-        dataType: "json",
-        headers: {
-            "X-CSRFToken": getCookie('csrftoken')
-        },
-        data: {
-            'credname': credname,
-            'topicname': topic_name,
-            'permission': ['Read'],
-        },
-        success: function (data, textStatus, jqXHR){
-            avail_table.row(trElem).remove().draw(false);
-            added_table.row.add([topic_name, topic_desc, topic_access, perm_box_format, remove_button_format]).draw(false);
-            //var row = avail_table.row(trElem);
-            //row.remove().draw();
-            //$('#added_permissions > tbody:last-child').append(table_1_format.format(topic_name, topic_desc, topic_access));
-        },
-        error: function(jqXHR, textStatus, errorThrown){
-            console.log('Error: ' + errorThrown);
-        },
-        complete: function(jqXHR, textStatus) {
-            console.log('Complete: ' + textStatus);
-        }
-    });
-      
-  }
-
-  function removeFromCallback() {
-      var trElem = $(this).closest('tr');
-      var credname = $('#idNameField').val();
-      var topic_name = $(trElem).find('td.topic_name').text();
-      var topic_desc = $(trElem).find('td.topic_desc').text();
-      var topic_access = $(trElem).find('td.topic_access').text();
-      dacp_link = $('#rcp_url').data().link;
-      $.ajax({
-            url: dacp_link,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                'credname': credname,
-                'topicname': topic_name,
-                'permission': ['Read', 'Write'],
-
-
-            },
-            success: function (data, textStatus, jqXHR){
-                //var rowNode = avail_table.row.add($(table_2_format.format(topic_name, topic_desc, topic_access))).draw(false);
-                //trElem.remove();
-                added_table.row(trElem).remove().draw(false);
-                avail_table.row.add([topic_name, topic_desc, topic_access, add_button_format]).draw(false);
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            }
-        });
-    }
-
-    function onReadCallback() {
+    progress_spinner = "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span>";
+    
+    function addPermCallback(){
         var credname = $('#idNameField').val();
+        var spanElem = $(this).closest('span');
         var trElem = $(this).closest('tr');
-        var isChecked = $(this).is(':checked');
         var topic_name = $(trElem).find('td.topic_name').text();
-        var readLink = isChecked ? $('#acp_url').data().link : $('#rcp_url').data().link;
-        $.ajax({
-            url: readLink,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                'credname': credname,
-                'topicname': topic_name,
-                'permission': ['Read'],
-            },
-            success: function (data, textStatus, jqXHR){
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            }
-        });
-    }
-
-    function onWriteCallback() {
-        var credname = $('#idNameField').val();
-        var trElem = $(this).closest('tr');
-        var isChecked = $(this).is(':checked');
-        var topic_name = $(trElem).find('td.topic_name').text();
-        var readLink = isChecked ? $('#acp_url').data().link : $('#rcp_url').data().link;
-        $.ajax({
-            url: readLink,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                'credname': credname,
-                'topicname': topic_name,
-                'permission': ['Write'],
-            },
-            success: function (data, textStatus, jqXHR){
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            }
-        });
-
+        var topic_desc = $(trElem).find('td.topic_desc').text();
+        var topic_access = $(trElem).find('td.topic_access').text();
+        var op_name = $(spanElem).contents().filter(function(){return this.nodeType == Node.TEXT_NODE; }).text().trim();
+        var readLink = $('#acp_url').data().link;
         
+        $(this).addClass("disabled");
+        $(this).text("");
+        $(this).prepend(progress_spinner);
+        
+        $.ajax({
+            url: readLink,
+            method: "POST",
+            dataType: "json",
+            headers: {
+                "X-CSRFToken": getCookie('csrftoken')
+            },
+            data: {
+                'credname': credname,
+                'topicname': topic_name,
+                'permission': [op_name],
+            },
+            success: function (data, textStatus, jqXHR){
+            },
+            error: function(jqXHR, textStatus, errorThrown){
+                $(this).removeClass("disabled");
+                $(this).text("Add");
+                //TODO: show error to user
+                console.log('Error: ' + errorThrown);
+            },
+            complete: function(jqXHR, textStatus) {
+                //add to other table, creating row if necessary
+                let cur_row=added_table.row((idx, data) => data[0] == topic_name)
+                if(cur_row.length==0)
+                    cur_row=added_table.row.add([topic_name, topic_desc, topic_access, ""]).draw(false);
+                console.log(cur_row);
+                var otherTr=cur_row.node();
+                $(otherTr).find('td.operations').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-danger remPerm objectModifier\">Remove</button></span> <br>");
+                //remove from this table, removing the whole row if empty
+                spanElem.remove();
+                var items = $(trElem).find('td.operations span').length;
+                if(items==0)
+                    avail_table.row(trElem).remove().draw(false);
+            }
+        });
     }
-
-  $('body').on('click', '.addToCur', addToCurCallback);
-
-  $('body').on('click', '.removeFrom', removeFromCallback);
-
-  $('body').on('click', '.readCheck', onReadCallback);
-
-  $('body').on('click', '.writeCheck', onWriteCallback);
+    
+    function remPermCallback(){
+        var credname = $('#idNameField').val();
+        var spanElem = $(this).closest('span');
+        var trElem = $(this).closest('tr');
+        var topic_name = $(trElem).find('td.topic_name').text();
+        var topic_desc = $(trElem).find('td.topic_desc').text();
+        var topic_access = $(trElem).find('td.topic_access').text();
+        var op_name = $(spanElem).contents().filter(function(){return this.nodeType == Node.TEXT_NODE; }).text().trim();
+        var readLink = $('#rcp_url').data().link;
+        var items = $(trElem).find('td.operations span').length; //should be computed only when ready to move elements
+        $(this).addClass("disabled");
+        $(this).text("");
+        $(this).prepend(progress_spinner);
+        
+        $.ajax({
+            url: readLink,
+            method: "POST",
+            dataType: "json",
+            headers: {
+                "X-CSRFToken": getCookie('csrftoken')
+            },
+            data: {
+                'credname': credname,
+                'topicname': topic_name,
+                'permission': [op_name],
+            },
+            success: function (data, textStatus, jqXHR){
+            },
+            error: function(jqXHR, textStatus, errorThrown){
+                $(this).removeClass("disabled");
+                $(this).text("Remove");
+                //TODO: show error to user
+                console.log('Error: ' + errorThrown);
+            },
+            complete: function(jqXHR, textStatus) {
+                //add to other table, creating row if necessary
+                let cur_row=avail_table.row((idx, data) => data[0] == topic_name)
+                if(cur_row.length==0)
+                    cur_row=avail_table.row.add([topic_name, topic_desc, topic_access, ""]).draw(false);
+                console.log(cur_row);
+                var otherTr=cur_row.node();
+                $(otherTr).find('td.operations').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-primary addPerm objectModifier\">Add</button></span> <br>");
+                //remove from this table, removing the whole row if empty
+                spanElem.remove();
+                var items = $(trElem).find('td.operations span').length;
+                if(items==0)
+                    added_table.row(trElem).remove().draw(false);
+            }
+        });
+    }
+  
+    $('body').on('click', '.addPerm', addPermCallback);
+    $('body').on('click', '.remPerm', remPermCallback);
 } );

--- a/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_topic.js
+++ b/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_topic.js
@@ -42,13 +42,6 @@ table_2_format = '<tr scope="row">\
 
 $(document).ready(function() {
     all_perms = ['Read', 'Write', 'Create', 'Delete', 'Alter', 'Describe', 'ClusterAction', 'DescribeConfigs', 'AlterConfigs', 'IdempotentWrite'];
-    edit_modal = null;
-    function initializeModal() {
-        modalElem = $('#topicPermEditModal');
-        edit_modal = new bootstrap.Modal($('#topicPermEditModal'), {
-          keyboard: false
-        })
-      }
 
     $('#id-selectOwnerForm #submit-id-cancel').click( function(event) {
         event.preventDefault();
@@ -68,7 +61,7 @@ $(document).ready(function() {
         'info': false,
         'columns': [
             {'className': 'group_name'},
-            {'className': 'remove_button', 'searchable': false, 'orderable': false}
+            {'className': 'permissions', 'searchable': false, 'orderable': false},
         ]
     });
 
@@ -76,10 +69,11 @@ $(document).ready(function() {
         'info': false,
         'columns': [
             {'className': 'group_name'},
-            {'className': 'perm_fields', 'searchable': false, 'orderable': false},
-            {'className': 'remove_button', 'searchable': false, 'orderable': false},
+            {'className': 'permissions', 'searchable': false, 'orderable': false},
         ]
     })
+    
+    progress_spinner = "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span>";
 
     function addedGroupCallback() {
         var trElem = $(this).closest('tr');
@@ -236,14 +230,103 @@ $(document).ready(function() {
             traditional: true,
         });
     }
+    
+    function addPermCallback(){
+        var spanElem = $(this).closest('span');
+        var trElem = $(this).closest('tr');
+        var groupname = $(trElem).find('td.group_name').text();
+        var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
+        var op_name = $(spanElem).contents().filter(function(){return this.nodeType == Node.TEXT_NODE; }).text().trim();
+        var readLink = $('#agp_url').data().link;
+        
+        $(this).addClass("disabled");
+        $(this).text("");
+        $(this).prepend(progress_spinner);
+        
+        $.ajax({
+            url: readLink,
+            method: "POST",
+            dataType: "json",
+            headers: {
+                "X-CSRFToken": getCookie('csrftoken')
+            },
+            data: {
+                topicname: topicname,
+                groupname: groupname,
+                permissions: op_name,
+            },
+            success: function (data, textStatus, jqXHR){
+            },
+            error: function(jqXHR, textStatus, errorThrown){
+                $(this).removeClass("disabled");
+                $(this).text("Add");
+                //TODO: show error to user
+                console.log('Error: ' + errorThrown);
+            },
+            complete: function(jqXHR, textStatus) {
+                //add to other table, creating row if necessary
+                let cur_row=added_table.row((idx, data) => data[0] == groupname)
+                if(cur_row.length==0)
+                    cur_row=added_table.row.add([groupname, ""]).draw(false);
+                var otherTr=cur_row.node();
+                $(otherTr).find('td.permissions').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-danger remPerm objectModifier\">Remove</button></span> <br>");
+                //remove from this table, removing the whole row if empty
+                spanElem.remove();
+                var items = $(trElem).find('td.permissions span').length;
+                if(items==0)
+                    avail_table.row(trElem).remove().draw(false);
+            }
+        });
+    }
+    
+    function remPermCallback(){
+        var spanElem = $(this).closest('span');
+        var trElem = $(this).closest('tr');
+        var groupname = $(trElem).find('td.group_name').text();
+        var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
+        var op_name = $(spanElem).contents().filter(function(){return this.nodeType == Node.TEXT_NODE; }).text().trim();
+        var readLink = $('#rgp_url').data().link;
+        var items = $(trElem).find('td.permissions span').length; //should be computed only when ready to move elements
+        $(this).addClass("disabled");
+        $(this).text("");
+        $(this).prepend(progress_spinner);
+        
+        $.ajax({
+            url: readLink,
+            method: "POST",
+            dataType: "json",
+            headers: {
+                "X-CSRFToken": getCookie('csrftoken')
+            },
+            data: {
+                topicname: topicname,
+                groupname: groupname,
+                permissions: op_name,
+            },
+            success: function (data, textStatus, jqXHR){
+            },
+            error: function(jqXHR, textStatus, errorThrown){
+                $(this).removeClass("disabled");
+                $(this).text("Remove");
+                //TODO: show error to user
+                console.log('Error: ' + errorThrown);
+            },
+            complete: function(jqXHR, textStatus) {
+                //add to other table, creating row if necessary
+                let cur_row=avail_table.row((idx, data) => data[0] == groupname)
+                if(cur_row.length==0)
+                    cur_row=avail_table.row.add([groupname, ""]).draw(false);
+                var otherTr=cur_row.node();
+                $(otherTr).find('td.permissions').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-primary addPerm objectModifier\">Add</button></span> <br>");
+                //remove from this table, removing the whole row if empty
+                spanElem.remove();
+                var items = $(trElem).find('td.permissions span').length;
+                if(items==0)
+                    added_table.row(trElem).remove().draw(false);
+            }
+        });
+    }
 
-    initializeModal();
-
-    $('body').on('click', '.addToCur', addedGroupCallback);
-
-    $('body').on('click', '.removeFrom', removedGroupCallback);
-
-    $('body').on('click', '.readCheck', onReadCallback);
-
-    $('body').on('click', '.writeCheck', onWriteCallback);
+    $('body').on('click', '.addPerm', addPermCallback);
+    $('body').on('click', '.remPerm', remPermCallback);
 });

--- a/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_topic.js
+++ b/scimma_admin/hopskotch_auth/static/hopskotch_auth/js/manage_topic.js
@@ -74,165 +74,10 @@ $(document).ready(function() {
     })
     
     progress_spinner = "<span class=\"spinner-border spinner-border-sm\" role=\"status\" aria-hidden=\"true\"></span>";
-
-    function addedGroupCallback() {
-        var trElem = $(this).closest('tr');
-        var groupname = trElem.find('td.group_name').text();
-        console.log(groupname);
-        var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
-        bsgp_link = $('#agp_url').data().link;
-        $.ajax({
-            url: bsgp_link,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                topicname: topicname,
-                groupname: groupname,
-                permissions: 'Read',
-            },
-            success: function (data, textStatus, jqXHR){
-                console.log('Success: ' + textStatus);
-                avail_table.row(trElem).remove().draw(false);
-                added_table.row.add([groupname, added_perm_format, '<button type="button" class="btn btn-danger removeFrom">Remove</button>']).draw(false);
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            },
-            traditional: true,
-        });
-    }
-
-    function removedGroupCallback() {
-        var trElem = $(this).closest('tr');
-        var groupname = trElem.find('td.group_name').text();
-        var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
-        bsgp_link = $('#rgp_url').data().link;
-        $.ajax({
-            url: bsgp_link,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                topicname: topicname,
-                groupname: groupname,
-                permissions: ['Read', 'Write'],
-            },
-            success: function (data, textStatus, jqXHR){
-                console.log('Success: ' + textStatus);
-                added_table.row(trElem).remove().draw(false);
-                avail_table.row.add(
-                    [
-                        groupname,
-                        '<button type="button" class="btn btn-primary addToCur">Add</button>'
-                    ]
-                ).draw();
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            },
-            traditional: true,
-        });
-    }
-
-    function onReadCallback() {
-        var trElem = $(this).closest('tr');
-        var isChecked = $(this).is(':checked');
-        var groupname = $(trElem).find('td.group_name').text();
-        var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
-        var gp_link = isChecked ? $('#agp_url').data().link : $('#rgp_url').data().link;
-        $.ajax({
-            url: gp_link,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                topicname: topicname,
-                groupname: groupname,
-                permissions: 'Read',
-            },
-            success: function (data, textStatus, jqXHR){
-                console.log('Success: ' + textStatus);
-                if (isChecked) {
-                    show_alert('Successfully gave {} Read Permission'.format(groupname), 'success');
-                }
-                else {
-                    show_alert("Successfully revoked {}'s Read Permission".format(groupname), 'success');
-                }
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-                if (isChecked) {
-                    show_alert('Failed to give {} Read Permission'.format(groupname), 'danger');
-                }
-                else {
-                    show_alert("Failed to revoke {}'s Read Permission".format(groupname), 'danger');
-                }
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            },
-            traditional: true,
-        });
-    }
-
-    function onWriteCallback() {
-        var trElem = $(this).closest('tr');
-        var isChecked = $(this).is(':checked');
-        var groupname = $(trElem).find('td.group_name').text();
-        var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
-        var gp_link = isChecked ? $('#agp_url').data().link : $('#rgp_url').data().link;
-        $.ajax({
-            url: gp_link,
-            method: "POST",
-            dataType: "json",
-            headers: {
-                "X-CSRFToken": getCookie('csrftoken')
-            },
-            data: {
-                topicname: topicname,
-                groupname: groupname,
-                permissions: 'Write',
-            },
-            success: function (data, textStatus, jqXHR){
-                console.log('Success: ' + textStatus);
-                if (isChecked) {
-                    show_alert('Successfully gave {} Write Permission'.format(groupname), 'success');
-                }
-                else {
-                    show_alert("Successfully revoked {}'s Write Permission".format(groupname), 'success');
-                }
-            },
-            error: function(jqXHR, textStatus, errorThrown){
-                console.log('Error: ' + errorThrown);
-                if (isChecked) {
-                    show_alert('Failed to give {} Write Permission'.format(groupname), 'danger');
-                }
-                else {
-                    show_alert("Failed to revoke {}'s Write Permission".format(groupname), 'danger');
-                }
-            },
-            complete: function(jqXHR, textStatus) {
-                console.log('Complete: ' + textStatus);
-            },
-            traditional: true,
-        });
-    }
     
     function addPermCallback(){
         var spanElem = $(this).closest('span');
+        var brElem = $(spanElem).next();
         var trElem = $(this).closest('tr');
         var groupname = $(trElem).find('td.group_name').text();
         var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
@@ -272,6 +117,7 @@ $(document).ready(function() {
                 $(otherTr).find('td.permissions').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-danger remPerm objectModifier\">Remove</button></span> <br>");
                 //remove from this table, removing the whole row if empty
                 spanElem.remove();
+                brElem.remove();
                 var items = $(trElem).find('td.permissions span').length;
                 if(items==0)
                     avail_table.row(trElem).remove().draw(false);
@@ -281,6 +127,7 @@ $(document).ready(function() {
     
     function remPermCallback(){
         var spanElem = $(this).closest('span');
+        var brElem = $(spanElem).next();
         var trElem = $(this).closest('tr');
         var groupname = $(trElem).find('td.group_name').text();
         var topicname = $('#id_owning_group_field').val() + '.' + $('#id_name_field').val();
@@ -320,6 +167,7 @@ $(document).ready(function() {
                 $(otherTr).find('td.permissions').append("<span display=\"inline-block\">"+op_name+"&nbsp;<button role=\"button\" style=\"padding-top: 0; padding-bottom:0;\" class=\"btn btn-sm btn-primary addPerm objectModifier\">Add</button></span> <br>");
                 //remove from this table, removing the whole row if empty
                 spanElem.remove();
+                brElem.remove();
                 var items = $(trElem).find('td.permissions span').length;
                 if(items==0)
                     added_table.row(trElem).remove().draw(false);

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/admin_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/admin_credential.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load django_bootstrap5 tz %}
 {% load static %}
 {% block title %}Home{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/admin_group.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/admin_group.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load django_bootstrap5 tz %}
 {% load static %}
 {% block title %}Home{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/admin_topic.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/admin_topic.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load django_bootstrap5 tz %}
 {% load static %}
 {% block title %}Home{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/base.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/base.html
@@ -23,7 +23,7 @@
         {% endblock %}
     </style>
     <body>
-        <nav class="navbar navbar-dark bg-dark fixed-top">
+        <nav class="navbar navbar-dark bg-dark">
             <div class="container-fluid">
                 {% if request.user.is_staff %}
                 <button class="navbar-toggler" type="button" data-bs-toggle="offcanvas" data-bs-target="#offcanvasNav" aria-controls="offcanvasNav">

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/base.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/base.html
@@ -32,6 +32,8 @@
                 {% endif %}
                 <h2 class="text-light col ms-3">
                     <a class="navbar-brand" href="/services"><img src="{% static 'hopskotch_auth/img/logo_transparent.png' %}" class="img-fluid"> SCiMMA Auth</a>
+                    {% block nav-section %}
+                    {% endblock %}
                 </h2>
                 <div id="navbarSupportedContent col">
                     <ul class="navbar-nav me-auto">

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/create_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/create_credential.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load static %}
 
 {% load crispy_forms_tags %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/create_group.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/create_group.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load static %}
 
 {% load crispy_forms_tags %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/create_topic.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/create_topic.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load crispy_forms_tags %}
 {% block title %}Create Topic{% endblock %}
 {% block page-header %}Create Topic{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/finished_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/finished_credential.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load static %}
 
 {% block title %}Create Credential{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/hopskotch.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/hopskotch.html
@@ -1,0 +1,6 @@
+{% extends "hopskotch_auth/base.html" %}
+
+{% block nav-section %}
+	<span class="navbar-brand">—</span>
+	<a class="navbar-brand" href="/hopauth">Hopskotch</a>
+{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/index.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/index.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load django_bootstrap5 tz %}
 {% load static %}
 {% block title %}Home{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
@@ -47,7 +47,7 @@
                       <th scope="col">Name</th>
                       <th scope="col">Description</th>
                       <th scope="col">Access Via</th>
-                      <th scope="col">Operations</th>
+                      <th scope="col">Permissions</th>
                   </thead>
                   <tbody>
                       {% for topic in added_topics %}
@@ -79,7 +79,7 @@
                         <th scope="col">Name</th>
                         <th scope="col">Description</th>
                         <th scope="col">Access Via</th>
-                        <th scope="col">Operations</th>
+                        <th scope="col">Permissions</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load static %}
 
 {% load crispy_forms_tags %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
@@ -3,8 +3,8 @@
 
 {% load crispy_forms_tags %}
 
-{% block title %}Create Credential{% endblock %}
-{% block page-header %}Create Credential{% endblock %}
+{% block title %}Manage Credential{% endblock %}
+{% block page-header %}Manage Credential{% endblock %}
 
 {% block page-body %}
 <meta id="gact_url" data-link="{% url 'get_available_credential_topics' %}">
@@ -14,11 +14,11 @@
 <meta id="acp_url" data-link="{% url 'add_credential_permissions' %}">
 <meta id="rcp_url" data-link="{% url 'remove_credential_permissions' %}">
 
-    <h2>Manage Credential</h2>
+    <h2>Manage Credential {{ cur_username }}</h2>
     <div class="container-fluid">
         <form class="form-horizontal" id="modifyCredentialForm" method="post">
           {% csrf_token %}
-          <div id="divNameField" class="mb-3 row">
+          <div id="divNameField" class="mb-3 row" style="display:none">
             <label for="idNameField" class="col-form-label col-lg-2">Username</label>
             <div class="col-lg-8">
               <input type="text" name="name_field" value="{{ cur_username }}" readonly="True" class="textinput textInput form-control" id="idNameField">
@@ -36,7 +36,7 @@
         </form>
           <h2>
             Current Permissions
-            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="All currently added permissions are here. In order to add (or remove) read or write access just click the box next to the perission you want to add or remove it from. The change is automatic and does not require any additional button presses" data-bs-original-title="Help">
+            <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="All permissions currently assigned to this credential are listed here. Click the 'Remove' button next to a permission to remove it." data-bs-original-title="Help">
               <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"/>
             </svg>
           </h2> 
@@ -68,7 +68,7 @@
         
         <h2>
           Available Permissions
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="A list of topics that are available to add to your credential. To add a permission click the 'Add' button next to the topic you want to add." data-bs-original-title="Help">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="A list of permissions that are available to add to your credential, grouped by topic. To add a permission click the 'Add' button next to it." data-bs-original-title="Help">
             <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"/>
           </svg>
         </h2>
@@ -112,7 +112,7 @@
                 <p>If you are a member of a group which owns one or more topics of its own, or has been granted access to one or more topics owned by another group, 
                 then on this page you will have the option to grant those permissions to your credential, enabling it to use them. 
                 To do so, locate the permission you wish to use in the 'Available Permissions' table (you may want to use the search function if you have many options), and click the associated 'Add' button.
-                If you need write access (to publish) rather than read access (to subscribe), toggle the check boxes in the 'Permissions' column of the 'Added Permissions' table as appropriate.
+                If you want to remove a permission you have previously added, locate it in the 'Current Permissions' table and click the associated 'Remove' button.
               </div>
             </div>
           </div>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_credential.html
@@ -27,7 +27,7 @@
           <div id="divDescriptionField" class="mb-3 row">
             <label for="idDescField" class="col-form-label col-lg-2">Description</label>
             <div class="col-lg-8">
-              <textarea name="desc_field" cols="40" rows="10" class="textarea form-control" id="idDescField">{{ cur_desc }}</textarea>
+              <textarea style="height: 4em;" name="desc_field" cols="40" rows="3" class="textarea form-control" id="idDescField">{{ cur_desc }}</textarea>
             </div>
           </div>
           <div class="d-grid gap-2 d-md-flex justify-content-md-end">
@@ -35,7 +35,7 @@
         </div> 
         </form>
           <h2>
-            Added Permissions
+            Current Permissions
             <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="All currently added permissions are here. In order to add (or remove) read or write access just click the box next to the perission you want to add or remove it from. The change is automatic and does not require any additional button presses" data-bs-original-title="Help">
               <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"/>
             </svg>
@@ -47,8 +47,7 @@
                       <th scope="col">Name</th>
                       <th scope="col">Description</th>
                       <th scope="col">Access Via</th>
-                      <th scope="col">Permissions</th>
-                      <th scope="col">Remove</th>
+                      <th scope="col">Operations</th>
                   </thead>
                   <tbody>
                       {% for topic in added_topics %}
@@ -56,9 +55,11 @@
                           <td class="topic_name">{{ topic.topic }}</td>
                           <td class="topic_desc">{{ topic.description }}</td>
                           <td class="topic_access">{{ topic.access_via }}</td>
-                          <!--<td class="edit_button"><button type="button" class="btn btn-primary editButton">Edit</button>-->
-                          <td class="perm_boxes">Read <input type="checkbox" class="form-check-input readCheck" {% if topic.read %}checked{% endif %}> Write <input type="checkbox" class="form-check-input writeCheck" {% if topic.write %}checked{% endif %}></td>
-                          <td scope="col" class="remove_button"><button type="button" class="btn btn-danger removeFrom objectModifier">Remove</button></td>
+                          <td class="operations">
+                              {% for perm in topic.permissions %}
+                              <span display="inline-block">{{ perm }}&nbsp;<button role="button" style="padding-top: 0; padding-bottom:0;" class="btn btn-sm btn-danger remPerm objectModifier">Remove</button></span> <br>
+                              {% endfor %}
+                          </td>
                       </tr>
                       {% endfor %}
                   </tbody>
@@ -78,7 +79,7 @@
                         <th scope="col">Name</th>
                         <th scope="col">Description</th>
                         <th scope="col">Access Via</th>
-                        <th scope="col">Add</th>
+                        <th scope="col">Operations</th>
                     </tr>
                 </thead>
                 <tbody>
@@ -87,11 +88,12 @@
                     <td class="topic_name">{{ topic.topic }}</td>
                     <td class="topic_desc">{{ topic.topic_description }}</td>
                     <td class="topic_access">{{ topic.accessible_by }}</td>
-                    <td>
-                      <form>
-                      <button type="button" class="btn btn-primary addToCur objectModifier">Add</button></td>
+                    <td class="operations">
+                        {% for perm in topic.permissions %}
+                        <span display="inline-block">{{ perm }}&nbsp;<button role="button" style="padding-top: 0; padding-bottom:0;" class="btn btn-sm btn-primary addPerm objectModifier">Add</button></span> <br>
+                        {% endfor %}
+                    </td>
                     </tr>
-                    {% empty %}
                     {% endfor %}
                 </tbody>
             </table>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_members.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_members.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load static %}
 
 {% load crispy_forms_tags %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_members.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_members.html
@@ -11,16 +11,17 @@
 <meta id="gam_url" data-link="{% url 'group_add_member' %}">
 <meta id="grm_url" data-link="{% url 'group_remove_member' %}">
     <div class="container">
-        <h2>Manage Group Members</h2>
+        <h2>Manage Members of Group {{ cur_name }}</h2>
+        <a href="{% url 'manage_group_topics' cur_name %}" class="btn btn-primary btn-sm">Manage this group's topics</a>
         <form method="POST">
             {% csrf_token %}
-            <div class="row">
+            <div class="row" style="display:none">
                 <label for="name_field" class="form-label">Name</label>
                 <input name="name_field" class="form-control" id="name_field" value="{{ cur_name }}" readonly>
             </div>
             <div class="row">
-                <label for="desc_field" class="form-label">Description</label>
-                <textarea id="desc_field" name="desc_field" class="form-field">{{ cur_description }}</textarea>
+                <label for="desc_field" class="form-label">Group Description:</label>
+                <textarea id="desc_field" name="desc_field" class="form-field" style="height: 5em;">{{ cur_description }}</textarea>
             </div>
             <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-2">
                 <button class="btn btn-primary" role="submit">Update Description</button>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_topics.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_topics.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load static %}
 
 {% load crispy_forms_tags %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_topics.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_group_topics.html
@@ -14,24 +14,24 @@
 <meta id="dt_url" data-link="{% url 'delete_topic' %}">
 <meta id="mt_url" data-link="{% url 'manage_topic' '{}' %}">
     <div class="container-fluid">
-        <h2>Manage Group Topics</h2>
+        <h2>Manage Topics Owned by Group {{ cur_name }}</h2>
+        <a href="{% url 'manage_group_members' cur_name %}" class="btn btn-primary btn-sm">Manage group members</a>
         <form method="POST">
           {% csrf_token %}
-          <div class="row">
+          <div class="row" style="display:none">
               <label for="name_field" class="form-label">Name</label>
               <input name="name_field" class="form-control" id="name_field" value="{{ cur_name }}" readonly>
           </div>
           <div class="row">
-              <label for="desc_field" class="form-label">Description</label>
-              <textarea id="desc_field" name="desc_field" class="form-field">{{ cur_description }}</textarea>
+              <label for="desc_field" class="form-label">Group Description:</label>
+              <textarea id="desc_field" name="desc_field" class="form-field" style="height: 5em;">{{ cur_description }}</textarea>
           </div>
           <div class="d-grid gap-2 d-md-flex justify-content-md-end mt-2">
-              <a class="btn btn-secondary" href="{% url 'index' %}">Cancel</a>
-              <button class="btn btn-primary" role="submit">Submit</button>
+              <button class="btn btn-primary" role="submit">Update Description</button>
           </div>
       </form>
         <h2>Existing Topics
-          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="All currently added topics. To edit the exact permissions for a topic click 'Edit'. To remove a topic from a group click 'Remove'" data-bs-original-title="Help">
+          <svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="All topics owned by this group. To edit the exact permissions for a topic click 'Edit'. To delete a topic click 'Remove'." data-bs-original-title="Help">
           <path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"/>
         </svg></h2>
         <div id="added_permissions">

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
@@ -1,4 +1,4 @@
-{% extends "hopskotch_auth/base.html" %}
+{% extends "hopskotch_auth/hopskotch.html" %}
 {% load crispy_forms_tags %}
 {% block title %}Manage Topic{% endblock %}
 {% block page-header %}Manage Topic{% endblock %}

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
@@ -72,7 +72,7 @@
         <table class="table" id="added_groups">
             <thead>
                 <th scope="col">Group</th>
-                <th scope="col">Permission</th>
+                <th scope="col">Permissions</th>
             </thead>
             <tbody>
                 {% for group in group_list %}
@@ -98,7 +98,7 @@
                 <thead>
                     <tr>
                         <th scope="col">Group</th>
-                        <th scope="col">Permission</th>
+                        <th scope="col">Permissions</th>
                     </tr>
                 </thead>
                 <tbody>

--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
@@ -9,16 +9,17 @@
 <meta id="agp_url" data-link="{% url 'add_topic_group_permission' %}">
 <meta id="rgp_url" data-link="{% url 'remove_topic_group_permission' %}">
     <div class="container-fluid">
-        <h2>Manage Topic</h2>
+        <h2>Manage Topic: {{ topic_name }}</h2>
+            <h3>Owned by group: <a href="{% url 'manage_group_topics' topic_owner %}">{{ topic_owner }}</a></h3>
             <form class="form-horizontal" id="id-createTopicForm" method="post">
                 {% csrf_token %}
-                <div id="div_id_owning_group_field" class="mb-3 row">
+                <div id="div_id_owning_group_field" class="mb-3 row" style="display:none">
                     <label for="id_owning_group_field" class="col-form-label col-lg-2 requiredField">Owning Group<span class="asteriskField">*</span></label>
                     <div class="col-lg-8">
                         <input type="text" name="owning_group_field" value="{{ topic_owner }}" class="row textinput textInput form-control" readonly="True" required="" id="id_owning_group_field">
                     </div> 
                 </div> 
-                <div id="div_id_name_field" class="mb-3 row">
+                <div id="div_id_name_field" class="mb-3 row" style="display:none">
                     <label for="id_name_field" class="col-form-label col-lg-2 requiredField">Name<span class="asteriskField">*</span></label>
                     <div class="col-lg-8"> 
                         <input type="text" name="name_field" value="{{ topic_name }}" class="row textinput textInput form-control" readonly="True" required="" id="id_name_field">
@@ -66,108 +67,55 @@
             </div> 
         </form>
     {% include "hopskotch_auth/messages.html" %}
-    <h2>Added Groups</h2>
+    <h2>Existing Permissions</h2>
     <div class="row mb-3">
         <table class="table" id="added_groups">
             <thead>
                 <th scope="col">Group</th>
                 <th scope="col">Permission</th>
-                <th scope="col">Remove</th>
             </thead>
             <tbody>
                 {% for group in group_list %}
                 <tr scope="row">
                     <td scope="col" class="group_name">{{ group.name }}</td>
-                    <td scope="col" class="perm_fields">{% if group.name == topic_owner %}{% else %}
-                      <div>
-                        Read <input class="readCheck" type="checkbox" {% if group.read %}checked{% endif %}> Write <input class="writeCheck" type="checkbox" {% if group.write %}checked{% endif %}>
-                      </div>
-                      {% endif %}</td>
-                    <td scope="col" class="remove_button">{% if group.name == topic_owner %}Owner{% else %}<button type="button" class="btn btn-danger removeFrom">Remove</button>{% endif %}</td>
+                    <td scope="col" class="permissions">
+                      {% if group.name == topic_owner %}
+                      All (Owner)
+                      {% else %}
+                        {% for perm in group.permissions %}
+                          <span display="inline-block">{{ perm }}&nbsp;<button role="button" style="padding-top: 0; padding-bottom:0;" class="btn btn-sm btn-danger remPerm objectModifier">Remove</button></span> <br>
+                        {% endfor %}
+                      {% endif %}
+                      </td>
                 </tr>
                 {% endfor %}
             </tbody>
         </table>
     </div>
-        <h2>Available Groups</h2>
+        <h2>Available Permissions</h2>
         <div id="cur_permissions">
             <table class="table table-hover" id="avail_table">
                 <thead>
                     <tr>
-                        <th scope="col">Group Name</th>
-                        <th scope="col">Add</th>
+                        <th scope="col">Group</th>
+                        <th scope="col">Permission</th>
                     </tr>
                 </thead>
                 <tbody>
                     {% for group in all_groups %}
                     <tr>
-                        <td scope="col" class="group_name">{{ group }}</td>
-                        <td scope="col" class="remove_button"><button type="button" class="btn btn-primary addToCur">Add</button></td>
+                        <td scope="col" class="group_name">{{ group.name }}</td>
+                        <td scope="col" class="permissions">
+                          {% for perm in group.permissions %}
+                            <span display="inline-block">{{ perm }}&nbsp;<button role="button" style="padding-top: 0; padding-bottom:0;" class="btn btn-sm btn-primary addPerm objectModifier">Add</button></span> <br>
+                          {% endfor %}
+                        </td>
                     </tr>
                     {% endfor %}
                 </tbody>
             </table>
         </div>
     </div>
-    <div class="modal fade" id="topicPermEditModal" tabindex="-1" aria-labelledby="topicPermEditLabel" aria-hidden="true">
-        <div class="modal-dialog">
-          <div class="modal-content">
-            <div class="modal-header">
-              <h5 class="modal-title" id="topicPermEditLabel">Modal title</h5>
-              <button type="button" class="btn-close" data-bs-dismiss="modal" aria-label="Close"></button>
-            </div>
-            <div class="modal-body">
-              <input type="hidden" id="currently_editing" value="">
-              <span class="border">
-                <div class="form-check form-switch">
-                  <label for="Read_perm" class="form-check-label">Read</label>
-                  <input type="checkbox" id="Read_perm" class="form-check-input" name="permCheck" value="Read">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="Write_perm" class="form-check-label">Write</label>
-                  <input type="checkbox" id="Write_perm" class="form-check-input" name="permCheck" value="Write">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="Create_perm" class="form-check-label">Create</label>
-                  <input type="checkbox" id="Create_perm" class="form-check-input" name="permCheck" value="Create">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="Delete_perm" class="form-check-label">Delete</label>
-                  <input type="checkbox" id="Delete_perm" class="form-check-input" name="permCheck" value="Delete">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="Alter_perm" class="form-check-label">Alter</label>
-                  <input type="checkbox" id="Alter_perm" class="form-check-input" name="permCheck" value="Alter">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="Describe_perm" class="form-check-label">Describe</label>
-                  <input type="checkbox" id="Describe_perm" class="form-check-input" name="permCheck" value="Describe">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="ClusterAction_perm" class="form-check-label">ClusterAction</label>
-                  <input type="checkbox" id="ClusterAction_perm" class="form-check-input" name="permCheck" value="ClusterAction">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="DescribeConfigs_perm" class="form-check-label">DescribeConfigs</label>
-                  <input type="checkbox" id="DescribeConfigs_perm" class="form-check-input" name="permCheck" value="DescribeConfigs">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="AlterConfigs_perm" class="form-check-label">AlterConfigs</label>
-                  <input type="checkbox" id="AlterConfigs_perm" class="form-check-input" name="permCheck" value="AlterConfigs">
-                </div>
-                <div class="form-check form-switch">
-                  <label for="IdempotentWrite_perm" class="form-check-label">IdempotentWrite</label>
-                  <input type="checkbox" id="IdempotentWrite_perm" class="form-check-input" name="permCheck" value="IdempotentWrite">
-                </div>
-              </span>
-            </div>
-            <div class="modal-footer">
-              <button type="button" class="btn btn-secondary" data-bs-dismiss="modal">Close</button>
-              <button type="button" class="btn btn-primary" id="save_edit">Save changes</button>
-            </div>
-          </div>
-        </div>
-      </div>
 {% endblock %}
 
 {% block scripts %}


### PR DESCRIPTION
This set of changes fixes the permissions management pages to be clearer and more robust. The primary change is to provide separate add/remove buttons for each permission so that it is always clear what pressing any given button will do. This and related bug fixes remove inconsistency between the front end and back end. Help text has been correspondingly updated, and some page titles fixed. 

Related, although not directly connected to the above changes, various navigation has been improved, including links back from individual topic pages to the owning groups' topic summary pages, and from each Hopskotch page to the top-level Hopskotch page. 