### PR TITLE
Broker awareness

### DIFF
--- a/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
+++ b/scimma_admin/hopskotch_auth/templates/hopskotch_auth/manage_topic.html
@@ -11,6 +11,11 @@
     <div class="container-fluid">
         <h2>Manage Topic: {{ topic_name }}</h2>
             <h3>Owned by group: <a href="{% url 'manage_group_topics' topic_owner %}">{{ topic_owner }}</a></h3>
+            {% if topic_url is not None %}
+            <h4>URL<sup><svg xmlns="http://www.w3.org/2000/svg" width="16" height="16" fill="currentColor" class="bi bi-question-circle-fill" viewBox="0 0 16 16" data-bs-toggle="popover" data-bs-trigger="hover" data-bs-content="Use this URL with the hop-client to subscribe or publish to this topic." data-bs-original-title="Help">
+						<path d="M16 8A8 8 0 1 1 0 8a8 8 0 0 1 16 0zM5.496 6.033h.825c.138 0 .248-.113.266-.25.09-.656.54-1.134 1.342-1.134.686 0 1.314.343 1.314 1.168 0 .635-.374.927-.965 1.371-.673.489-1.206 1.06-1.168 1.987l.003.217a.25.25 0 0 0 .25.246h.811a.25.25 0 0 0 .25-.25v-.105c0-.718.273-.927 1.01-1.486.609-.463 1.244-.977 1.244-2.056 0-1.511-1.276-2.241-2.673-2.241-1.267 0-2.655.59-2.75 2.286a.237.237 0 0 0 .241.247zm2.325 6.443c.61 0 1.029-.394 1.029-.927 0-.552-.42-.94-1.029-.94-.584 0-1.009.388-1.009.94 0 .533.425.927 1.01.927z"/>
+					</svg></sup>: {{ topic_url }}</h4>
+            {% endif %}
             <form class="form-horizontal" id="id-createTopicForm" method="post">
                 {% csrf_token %}
                 <div id="div_id_owning_group_field" class="mb-3 row" style="display:none">

--- a/scimma_admin/hopskotch_auth/views.py
+++ b/scimma_admin/hopskotch_auth/views.py
@@ -433,11 +433,16 @@ def manage_topic(request, topicname) -> HttpResponse:
                     }
                 other_groups[group]["permissions"].append(op.name)
     short_name = topic.name[len(topic.owning_group.name)+1:] if topic.name.startswith(topic.owning_group.name+'.') else topic.name
+    if settings.KAFKA_BROKER_URL is not None:
+        topic_url = f"kafka://{settings.KAFKA_BROKER_URL}/{topic.owning_group.name}.{short_name}"
+    else:
+        topic_url = None
     return render(request,
             'hopskotch_auth/manage_topic.html',
             {'topic_owner': topic.owning_group.name,
             'topic_name': short_name,
             'topic_desc': topic.description,
+            'topic_url': topic_url,
             'is_visible': topic.publicly_readable,
             'is_archivable': topic.archivable,
             'all_groups': list(other_groups.values()),

--- a/scimma_admin/hopskotch_auth/views.py
+++ b/scimma_admin/hopskotch_auth/views.py
@@ -65,8 +65,13 @@ def client_ip(request: HttpRequest) -> str:
 
 def download(request: AuthenticatedHttpRequest) -> HttpResponse:
     myfile = StringIO()
-    myfile.write("username,password\n")
-    myfile.write(f"{request.POST['username']},{request.POST['password']}")
+    data = {"username": request.POST["username"],
+            "password": request.POST["password"]}
+    if settings.KAFKA_BROKER_URL is not None:
+        data["hostname"] = settings.KAFKA_BROKER_URL
+    myfile.write(','.join(data.keys()))
+    myfile.write('\n')
+    myfile.write(','.join(data.values()))
     myfile.flush()
     myfile.seek(0) # move the pointer to the beginning of the buffer
     response = HttpResponse(FileWrapper(myfile), content_type='text/plain')

--- a/scimma_admin/scimma_admin/settings.py
+++ b/scimma_admin/scimma_admin/settings.py
@@ -318,6 +318,13 @@ REST_FRAMEWORK = {
     ),
 }
 
+KAFKA_BROKER_URL = os.environ.get("KAFKA_BROKER_URL", default=None)
+if KAFKA_BROKER_URL is None:
+    if SCIMMA_ENVIRONMENT == "dev":
+        KAFKA_BROKER_URL = "dev.hop.scimma.org"
+    elif SCIMMA_ENVIRONMENT == "prod":
+        KAFKA_BROKER_URL = "kafka.scimma.org"
+
 
 try:
     from local_settings import *


### PR DESCRIPTION
This patchset teaches the admin interface to be able to know the Kafka broker URL and use it:
- to show topic URLs on the individual management pages, to help guide users (https://github.com/scimma/scimma-admin/issues/74)
- in downloadable credential CSV files, so that the user's client will know the broker with which the credential is associated